### PR TITLE
postgres docker instructions, docker-compose and bash script

### DIFF
--- a/blockchain-explorer/README.md
+++ b/blockchain-explorer/README.md
@@ -17,7 +17,9 @@ The instructions below are complete. You can refer to the instructions in the Hy
 | RDS - PostgreSQL | Docker - PostgreSQL |
 | --- | --- |
 | [Pre-requisites](#pre-requisites) | (no change) |
-| [Step 1 - Clone the appropriate version of the Hyperledger Explorer repository](#step-1---clone-the-appropriate-version-of-the-hyperledger-explorer-repository) | (no change) | 
+| [Step 1 - Clone the appropriate version of the Hyperledger Explorer repository](#step-1---clone-the-appropriate-version-of-the-hyperledger-explorer-repository) | (no change) |
+| [Step 2 - Create the Amazon RDS PostgreSQL instance used by Hyperledger Explorer](#step-2---create-the-Amazon-RDS-PostgreSQL-instance-used-by-Hyperledger-Explorer) | [Step 2 (Docker Postgres) - Deploy Postgres Database Docker Image](#step-2-(Docker-Postgres)---Deploy-Postgres-Database-Docker-Image) |
+
 
 ## Pre-requisites
 
@@ -96,7 +98,7 @@ cd ~/non-profit-blockchain/blockchain-explorer
 ./hyperledger-explorer-rds.sh
 ```
 
-## Step 2 (Docker Postgres) -  Deploy Postgres Database as Docker
+## Step 2 (Docker Postgres) - Deploy Postgres Database Docker Image
 
 We can also use Docker`s official postgres image (https://hub.docker.com/_/postgres_) to persist FabricExplorer data, locally in the fabric client. You need PostgreSQL 9.5 or greater; therefore you can keep the latest image tag (at the time this piece is written the latest version was 11.3).
 

--- a/blockchain-explorer/README.md
+++ b/blockchain-explorer/README.md
@@ -112,12 +112,12 @@ If you pick the script path, create the file with script contents:
 ```
 touch ~/postgres-fabricexplorer.sh
 ```
-and copy the contents by using your favorite tool (such as vim or emacs). Then provide execute privileges to your current user:
+and copy the contents by using your favorite tool (such as vim or emacs). The scripts is included in "postgres-fabricexplorer" folder [here](postgres-fabricexplorer.sh). Then provide execute privileges to your current user:
 ```
 chmod +x ~/postgres-fabricexplorer.sh
 ```
 
-If you want to follow steps manually, then:
+If you want to follow steps manually, then you can continue from here:
 
 You may also want to create a dedicated folder to keep postgres database and docker configuration files. 
 

--- a/blockchain-explorer/README.md
+++ b/blockchain-explorer/README.md
@@ -18,7 +18,7 @@ The instructions below are complete. You can refer to the instructions in the Hy
 | --- | --- |
 | [Pre-requisites](#pre-requisites) | (no change) |
 | [Step 1 - Clone the appropriate version of the Hyperledger Explorer repository](#step-1---clone-the-appropriate-version-of-the-hyperledger-explorer-repository) | (no change) |
-| [Step 2 - Create the Amazon RDS PostgreSQL instance used by Hyperledger Explorer](#step-2---create-the-Amazon-RDS-PostgreSQL-instance-used-by-Hyperledger-Explorer) | [Step 2 - Docker Postgres - Deploy Postgres Database Docker Image](#step-2-Docker-Postgres---Deploy-Postgres-Database-Docker-Image) |
+| [Step 2 - Create the Amazon RDS PostgreSQL instance used by Hyperledger Explorer](#step-2---create-the-Amazon-RDS-PostgreSQL-instance-used-by-Hyperledger-Explorer) | [Step 2 - Docker Postgres - Deploy Postgres Database Docker Image](#step-2---Docker-Postgres---Deploy-Postgres-Database-Docker-Image) |
 
 
 ## Pre-requisites

--- a/blockchain-explorer/README.md
+++ b/blockchain-explorer/README.md
@@ -108,7 +108,7 @@ cd ~/non-profit-blockchain/blockchain-explorer
 We can also use Docker`s official postgres image (https://hub.docker.com/_/postgres_) to persist FabricExplorer data, locally in the fabric client. You need PostgreSQL 9.5 or greater; therefore you can keep the latest image tag (at the time this piece is written the latest version was 11.3).
 
 We can either follow instructions below and go through steps manually, or run the "postgres-fabricexplorer.sh" script (script simply goes through steps below). 
-If you pick the script path, create the file with script contents:
+If you pick the script path, create the file:
 ```
 touch ~/postgres-fabricexplorer.sh
 ```

--- a/blockchain-explorer/README.md
+++ b/blockchain-explorer/README.md
@@ -112,7 +112,7 @@ If you pick the script path, create the file:
 ```
 touch ~/postgres-fabricexplorer.sh
 ```
-and copy the contents by using your favorite tool (such as vim or emacs). The scripts is included in "postgres-fabricexplorer" folder [here](https://github.com/vrnsn/non-profit-blockchain/blob/feature/part6-evren/blockchain-explorer/postgres-fabricexplorer/postgres-fabricexplorer.sh). Then provide execute privileges to your current user:
+and copy the contents by using your favorite tool (such as vim or emacs). The script is included in "postgres-fabricexplorer" folder [here](https://github.com/vrnsn/non-profit-blockchain/blob/feature/part6-evren/blockchain-explorer/postgres-fabricexplorer/postgres-fabricexplorer.sh). Then provide execute privileges to your current user:
 ```
 chmod +x ~/postgres-fabricexplorer.sh
 ```

--- a/blockchain-explorer/README.md
+++ b/blockchain-explorer/README.md
@@ -19,6 +19,11 @@ The instructions below are complete. You can refer to the instructions in the Hy
 | [Pre-requisites](#pre-requisites) | (no change) |
 | [Step 1 - Clone the appropriate version of the Hyperledger Explorer repository](#step-1---clone-the-appropriate-version-of-the-hyperledger-explorer-repository) | (no change) |
 | [Step 2 - Create the Amazon RDS PostgreSQL instance used by Hyperledger Explorer](#step-2---create-the-Amazon-RDS-PostgreSQL-instance-used-by-Hyperledger-Explorer) | [Step 2 - Docker Postgres - Deploy Postgres Database Docker Image](#step-2---Docker-Postgres---Deploy-Postgres-Database-Docker-Image) |
+| [Step 3 - Create the Hyperledger Explorer database tables in the PostgreSQL RDS database](#Step-3---Create-the-Hyperledger-Explorer-database-tables-in-the-PostgreSQL-RDS-database) | [Step 3 - Docker Postgres - Create the Hyperledger Explorer database tables in the Docker PostgreSQL database](#Step-3---Docker-Postgres---Create-the-Hyperledger-Explorer-database-tables-in-the-Docker-PostgreSQL-database) |
+| [Step 4 - Create a connection profile to connect Hyperledger Explorer to Amazon Managed Blockchain](#Step-4---Create-a-connection-profile-to-connect-Hyperledger-Explorer-to-Amazon-Managed-Blockchain) | (no change) |
+| [Step 5 - Run Hyperledger Explorer and view the dashboard](#Step-5---Run-Hyperledger-Explorer-and-view-the-dashboard) | (no change) |
+| [Step 6 - Use the Swagger Open API Specification UI to interact with Hyperledger Explorer](#Step-6---Use-the-Swagger-Open-API-Specification-UI-to-interact-with-Hyperledger-Explorer) | (no change) |
+| [Step 7 - Keeping Hyperledger Explorer Running](#Step-7---Keeping-Hyperledger-Explorer-Running) | (no change) | 
 
 
 ## Pre-requisites
@@ -218,7 +223,7 @@ If you need to connect to psql via the command line, use this (replacing the RDS
 psql -X -h sd1erq6vwko24hx.ce2rsaaq7nas.us-east-1.rds.amazonaws.com -d fabricexplorer --username=master 
 ```
 
-## Step 3 (Docker Postgres) - Create the Hyperledger Explorer database tables in the PostgreSQL docker database
+## Step 3 - Docker Postgres - Create the Hyperledger Explorer database tables in the Docker PostgreSQL database
 Once step 2 has completed and your PostgreSQL instance is running, you will create tables in a PostgreSQL database. These tables are used by Hyperledger Explorer to store details of your Fabric network. Before running the script to create the tables, update the Hyperledger Explorer table creation script. The columns created by the script are too small to contain the long peer names used by Managed Blockchain, so we edit the script to increase the length:
 
 ```

--- a/blockchain-explorer/README.md
+++ b/blockchain-explorer/README.md
@@ -217,7 +217,7 @@ cd ~/blockchain-explorer/app/persistence/fabric/postgreSQL/db
 ./createdb.sh
 ```
 
-If you need to connect to psql via the command line, use this to connect to the client postgresql instance :
+If you need to connect to psql via the command line, use this (replacing the RDS DNS with your own):
 
 ```
 psql -X -h sd1erq6vwko24hx.ce2rsaaq7nas.us-east-1.rds.amazonaws.com -d fabricexplorer --username=master 
@@ -293,7 +293,7 @@ cd ~/blockchain-explorer/app/persistence/fabric/postgreSQL/db
 ./createdb.sh
 ```
 
-If you need to connect to psql via the command line, use this (replacing the RDS DNS with your own):
+If you need to connect to psql via the command line, use this to connect to the client postgresql instance :
 
 ```
 psql -X -h localhost -d fabricexplorer --username=superuser 

--- a/blockchain-explorer/README.md
+++ b/blockchain-explorer/README.md
@@ -16,8 +16,8 @@ The instructions below are complete. You can refer to the instructions in the Hy
 
 | RDS - PostgreSQL | Docker - PostgreSQL |
 | --- | --- |
-| [Pre-requisites](#-pre-requisites) |
-| [Step 1 - Clone the appropriate version of the Hyperledger Explorer repository](#-step-1---clone-the-appropriate-version-of-the-hyperledger-explorer-repository) | 
+| [Pre-requisites](#pre-requisites) | (no change) |
+| [Step 1 - Clone the appropriate version of the Hyperledger Explorer repository](#step-1---clone-the-appropriate-version-of-the-hyperledger-explorer-repository) | (no change) | 
 
 ## Pre-requisites
 

--- a/blockchain-explorer/README.md
+++ b/blockchain-explorer/README.md
@@ -217,7 +217,7 @@ cd ~/blockchain-explorer/app/persistence/fabric/postgreSQL/db
 ./createdb.sh
 ```
 
-If you need to connect to psql via the command line, use this (replacing the RDS DNS with your own):
+If you need to connect to psql via the command line, use this to connect to the client postgresql instance :
 
 ```
 psql -X -h sd1erq6vwko24hx.ce2rsaaq7nas.us-east-1.rds.amazonaws.com -d fabricexplorer --username=master 

--- a/blockchain-explorer/README.md
+++ b/blockchain-explorer/README.md
@@ -112,7 +112,7 @@ If you pick the script path, create the file with script contents:
 ```
 touch ~/postgres-fabricexplorer.sh
 ```
-and copy the contents by using your favorite tool (such as vim or emacs). The scripts is included in "postgres-fabricexplorer" folder [here](postgres-fabricexplorer.sh). Then provide execute privileges to your current user:
+and copy the contents by using your favorite tool (such as vim or emacs). The scripts is included in "postgres-fabricexplorer" folder [here](https://github.com/vrnsn/non-profit-blockchain/blob/feature/part6-evren/blockchain-explorer/postgres-fabricexplorer/postgres-fabricexplorer.sh). Then provide execute privileges to your current user:
 ```
 chmod +x ~/postgres-fabricexplorer.sh
 ```

--- a/blockchain-explorer/README.md
+++ b/blockchain-explorer/README.md
@@ -91,6 +91,50 @@ cd ~/non-profit-blockchain/blockchain-explorer
 ./hyperledger-explorer-rds.sh
 ```
 
+## Step 2 (option) -  Deploy Postgres Database as Docker
+
+We can also use Docker`s official postgres image (https://hub.docker.com/_/postgres_) to persist FabricExplorer data, locally in the fabric client. You need PostgreSQL 9.5 or greater; therefore you can keep the latest image tag (at the time this piece is written the latest version was 11.3).
+
+You may also want to create a dedicated folder to keep postgres database and docker configuration files. 
+
+Create Postgres folders:
+```
+mkdir ~/postgres-fabricexplorer
+mkdir ~/postgres-fabricexplorer/pgdata
+```
+
+We are going to keep the docker file for postgres simple; however you can further customize your deployment by following instructions in the link above. You can either create the file yourself; or use the file "postgres-compose.yml".
+
+"postgres-compose.yml" file:
+```
+version: '3.1'
+
+services:
+  db:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_USER: superuser
+      POSTGRES_PASSWORD: superuser1234
+    volumes:
+      - ~/postgres-fabricexplorer/pgdata:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
+```
+
+We can now start the postgres container in detached mode:
+
+```
+docker-compose -f ~/postgres-fabricexplorer/postgres-compose.yml up -d
+```
+
+The docker image will expose and map postgres port 5432 to the same port of the client. Please make sure to check container logs to see database is ready to accept connections:
+```
+docker ps
+docker logs <postgres-container-id/name>
+```
+
+
 ## Step 3 - Create the Hyperledger Explorer database tables in the PostgreSQL RDS database
 
 Once step 2 has completed and your PostgreSQL instance is running, you will create tables in a PostgreSQL database. These tables are used by Hyperledger Explorer to store details of your Fabric network. Before running the script to create the tables, update the Hyperledger Explorer table creation script. The columns created by the script are too small to contain the long peer names used by Managed Blockchain, so we edit the script to increase the length:

--- a/blockchain-explorer/README.md
+++ b/blockchain-explorer/README.md
@@ -18,7 +18,7 @@ The instructions below are complete. You can refer to the instructions in the Hy
 | --- | --- |
 | [Pre-requisites](#pre-requisites) | (no change) |
 | [Step 1 - Clone the appropriate version of the Hyperledger Explorer repository](#step-1---clone-the-appropriate-version-of-the-hyperledger-explorer-repository) | (no change) |
-| [Step 2 - Create the Amazon RDS PostgreSQL instance used by Hyperledger Explorer](#step-2---create-the-Amazon-RDS-PostgreSQL-instance-used-by-Hyperledger-Explorer) | [Step 2 (Docker Postgres) - Deploy Postgres Database Docker Image](#step-2-(Docker-Postgres)---Deploy-Postgres-Database-Docker-Image) |
+| [Step 2 - Create the Amazon RDS PostgreSQL instance used by Hyperledger Explorer](#step-2---create-the-Amazon-RDS-PostgreSQL-instance-used-by-Hyperledger-Explorer) | [Step 2 - Docker Postgres - Deploy Postgres Database Docker Image](#step-2-Docker-Postgres---Deploy-Postgres-Database-Docker-Image) |
 
 
 ## Pre-requisites
@@ -98,7 +98,7 @@ cd ~/non-profit-blockchain/blockchain-explorer
 ./hyperledger-explorer-rds.sh
 ```
 
-## Step 2 (Docker Postgres) - Deploy Postgres Database Docker Image
+## Step 2 - Docker Postgres - Deploy Postgres Database Docker Image
 
 We can also use Docker`s official postgres image (https://hub.docker.com/_/postgres_) to persist FabricExplorer data, locally in the fabric client. You need PostgreSQL 9.5 or greater; therefore you can keep the latest image tag (at the time this piece is written the latest version was 11.3).
 

--- a/blockchain-explorer/README.md
+++ b/blockchain-explorer/README.md
@@ -107,6 +107,18 @@ cd ~/non-profit-blockchain/blockchain-explorer
 
 We can also use Docker`s official postgres image (https://hub.docker.com/_/postgres_) to persist FabricExplorer data, locally in the fabric client. You need PostgreSQL 9.5 or greater; therefore you can keep the latest image tag (at the time this piece is written the latest version was 11.3).
 
+We can either follow instructions below and go through steps manually, or run the "postgres-fabricexplorer.sh" script (script simply goes through steps below). 
+If you pick the script path, create the file with script contents:
+```
+touch ~/postgres-fabricexplorer.sh
+```
+and copy the contents by using your favorite tool (such as vim or emacs). Then provide execute privileges to your current user:
+```
+chmod +x ~/postgres-fabricexplorer.sh
+```
+
+If you want to follow steps manually, then:
+
 You may also want to create a dedicated folder to keep postgres database and docker configuration files. 
 
 Create Postgres folders:

--- a/blockchain-explorer/postgres-fabricexplorer/postgres-compose.yml
+++ b/blockchain-explorer/postgres-fabricexplorer/postgres-compose.yml
@@ -1,0 +1,14 @@
+version: '3.1'
+
+services:
+
+  db:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_USER: superuser
+      POSTGRES_PASSWORD: superuser1234
+    volumes:
+      - ~/postgres-fabricexplorer/pgdata:/var/lib/postgresql/data
+    ports:
+      - 5432:5432

--- a/blockchain-explorer/postgres-fabricexplorer/postgres-fabricexplorer.sh
+++ b/blockchain-explorer/postgres-fabricexplorer/postgres-fabricexplorer.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# or in the "license" file accompanying this file. This file is distributed 
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+# express or implied. See the License for the specific language governing 
+# permissions and limitations under the License.
+
+
+# Create dedicated folders to keep postgres database and docker configuration files.
+echo Creating folders for PostgreSQL docker configuration and database files.
+mkdir ~/postgres-fabricexplorer
+mkdir ~/postgres-fabricexplorer/pgdata
+
+# Create docker compose file
+echo Creating docker-compose file for PostgreSQL.
+
+cat <<EOF >~/postgres-fabricexplorer/postgres-compose.yml
+version: '3.1'
+
+services:
+  db:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_USER: superuser
+      POSTGRES_PASSWORD: superuser1234
+    volumes:
+      - ~/postgres-fabricexplorer/pgdata:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
+EOF
+
+ls -l ~/postgres-fabricexplorer
+
+# Start Docker container
+echo Starting Postres container.
+docker-compose -f ~/postgres-fabricexplorer/postgres-compose.yml up -d
+
+# Verify container is working and database has started accepting connections
+echo Verifying Postgres container is up and accepting connections.
+
+postgres_container_name=$(docker ps | grep -oP '(postgresf).*')
+docker logs $postgres_container_name
+
+


### PR DESCRIPTION
Issue #, if available:

Description of changes:

- postgres docker instructions (manual or with a bash script) added to Readme with their own sections (sections 2 and 3).
- docker compose and bash scripts included in a folder.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
